### PR TITLE
Python 26 compatibility

### DIFF
--- a/src/ZTUtils/Zope.py
+++ b/src/ZTUtils/Zope.py
@@ -228,6 +228,13 @@ def make_hidden_input(*args, **kwargs):
 
     return '\n'.join(qlist)
 
+def isPrimitive(obj):
+    if hasattr(obj, 'items'):
+        return False
+    if isinstance(obj, list):
+        return False
+    return True
+
 def complex_marshal(pairs):
     '''Add request marshalling information to a list of name-value pairs.
 
@@ -245,13 +252,6 @@ def complex_marshal(pairs):
     addition to their simple marshal string.  Dictionaries will be
     flattened and marshalled using ":record".
     '''
-
-    def isPrimitive(obj):
-        if hasattr(v, 'items'):
-            return False
-        if isinstance(v, list):
-            return False
-        return True
 
     triples = []
 

--- a/src/ZTUtils/tests/testZope.py
+++ b/src/ZTUtils/tests/testZope.py
@@ -75,12 +75,12 @@ class QueryTests(TestCase):
         self.maxDiff = 1000
 
         #dictionaries dont' preserve order - use self.assertItemsEqual
-        self.assertItemsEqual(result,
-                              [('r_record.arg1', ':record', 'top'),
-                               ('r_record.arg2.sub1', ':record:record', 'deep'),
-                               ('r_record.arg2.sub2', ':int:record:record', 1),
-                               ('r_record.arg3', ':int:record', 12)]
-                              )
+        self.assertEqual(sorted(result),
+                         [('r_record.arg1', ':record', 'top'),
+                          ('r_record.arg2.sub1', ':record:record', 'deep'),
+                          ('r_record.arg2.sub2', ':int:record:record', 1),
+                          ('r_record.arg3', ':int:record', 12),
+                         ])
 
     def testMarshallListsInLists(self):
         '''Test marshalling lists in lists'''


### PR DESCRIPTION
- Use compatible unittest assertion.
- Remove currying artifacts inside `ZTUtils.Zope.complex_marshal`:  trying to work around Python 2.6, where RuntimeError for recursion is being swallowed inside an AttributeError.
